### PR TITLE
Fix fixtures reference and rake db:nuke_pave

### DIFF
--- a/db/samples.rb
+++ b/db/samples.rb
@@ -1,8 +1,13 @@
 require 'active_record/fixtures'
+require 'fileutils'
 
 puts "adding seed data from fixtures..."
 
 Dir.glob(File.join(Rails.root, "db", "fixtures", "*.csv")).each do |file|
   puts "Adding data from: " + File.basename(file)
-  Fixtures.create_fixtures('db/fixtures', File.basename(file, '.*'))
+  fixture_filename = File.join('db', 'fixtures', File.basename(file, '.*'))
+
+  # Throws exception if 'db/fixtures/#{filename}.yml' doesn't yet exist
+  FileUtils.touch(fixture_filename)
+  ActiveRecord::Fixtures.create_fixtures(fixture_filename)
 end


### PR DESCRIPTION
- s/Fixtures/ActiveRecord::Fixtures/g (necessary for > 4.0 Rails)
- Touches a 'db/fixtures/#{filename}.yml' because create_fixtures
  doesn't seem to create file if not present.
