### PR TITLE
Optimizes retailer import

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'rails', '~> 4.2.3'
 
 
 # DB's
-gem 'pg', '~> 0.17.0'
+gem 'pg', '~> 0.18.2'
 
 # Assets
 gem 'sass-rails', '~> 4.0.1'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,7 +89,7 @@ GEM
     multi_json (1.11.2)
     nokogiri (1.6.6.2)
       mini_portile (~> 0.6.0)
-    pg (0.17.1)
+    pg (0.18.2)
     pry (0.9.12.2)
       coderay (~> 1.0.5)
       method_source (~> 0.8)
@@ -182,7 +182,7 @@ DEPENDENCIES
   jquery-rails (~> 3.0.4)
   jquery_mobile_rails (~> 1.4.5)
   minitest-spec-rails (~> 5.2.2)
-  pg (~> 0.17.0)
+  pg (~> 0.18.2)
   pry (~> 0.9.12)
   rails (~> 4.2.3)
   rake
@@ -193,6 +193,3 @@ DEPENDENCIES
   vcr
   webmock
   whenever (~> 0.8.4)
-
-BUNDLED WITH
-   1.10.6

--- a/lib/tasks/db.rake
+++ b/lib/tasks/db.rake
@@ -25,7 +25,7 @@ namespace :db do
   desc "Deletes retailers, downloads, and reloads all retailers from USDA"
   task :datarefresh => :environment do
     require File.join(Rails.root, "lib", "retailers_importer.rb")
-    RetailersImporter.new.run
+    RetailersImporter.call
   end
 
 end


### PR DESCRIPTION
19X faster with no increase in memory usage!
- Cuts out active record models by constructing raw sql (9.5 min -> 3.5 min)
- Batches inserts to 1000 rows at a time (3.5 min -> 0.5 min)
  - larger batch sizes can marginally speed up the load but uses more memory(10,000 rows- 10% faster, 15% more memory)
  - Inserting all 250k rows at once is slower (1.5 min)  and uses a lot more memory (4.5x for rake process and (28x for postgres)

other changes
- Bumps pg gem version to 0.18.2 (0.17 is buggy)
- uses `Dir.mktmpdir` instead of manually manageing the temp directory
