### PR TITLE
Remove build artifact after rake db:sample

### DIFF
--- a/db/samples.rb
+++ b/db/samples.rb
@@ -12,4 +12,6 @@ Dir.glob(File.join(Rails.root, "db", "fixtures", "*.csv")).each do |file|
   fixtures = File.join('db/fixtures', "#{File.basename(file, '.*')}.yml")
   FileUtils.touch(fixtures)
   ActiveRecord::Fixtures.create_fixtures(*db_args)
+  # Now that ActiveRecord::Fixtures is happy, let's remove the file
+  FileUtils.rm(fixtures, force: true)
 end


### PR DESCRIPTION
samples.rb is currently leaving a yml file as a build artifact. This PR fixes the issue by removing spare build file after rake task completes.
